### PR TITLE
added String modifier to parse-string

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "2.0.0",
-    "summary": "A parser combinator library",
-    "repository": "https://github.com/elm-community/parser-combinators.git",
+    "summary": "A fork of the elm-community/parser-combinator, with function modifyStream.",
+    "repository": "https://github.com/andre-dietrich/parser-combinators.git",
     "license": "BSD3",
     "source-directories": [
         "examples",

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,7 +1,7 @@
 {
-    "version": "1.0.0",
-    "summary": "A fork of the elm-community/parser-combinator, with function modifyStream.",
-    "repository": "https://github.com/andre-dietrich/parser-combinators.git",
+    "version": "2.0.0",
+    "summary": "A parser combinator library",
+    "repository": "https://github.com/elm-community/parser-combinators.git",
     "license": "BSD3",
     "source-directories": [
         "examples",

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "1.0.0",
     "summary": "A fork of the elm-community/parser-combinator, with function modifyStream.",
     "repository": "https://github.com/andre-dietrich/parser-combinators.git",
     "license": "BSD3",

--- a/src/Combine.elm
+++ b/src/Combine.elm
@@ -22,6 +22,7 @@ module Combine
         , currentSourceLine
         , currentLine
         , currentColumn
+        , modifyStream
         , map
         , mapError
         , andThen
@@ -510,6 +511,14 @@ currentColumn : InputStream -> Int
 currentColumn =
     currentLocation >> .column
 
+
+{-| Modify the parser's InputStream.
+-}
+modifyStream : (String -> String) -> Parser s ()
+modifyStream f =
+    Parser <|
+        \state stream ->
+            app (succeed ()) state { stream | input = f stream.input }
 
 
 -- Transformers

--- a/src/Combine.elm
+++ b/src/Combine.elm
@@ -126,7 +126,7 @@ into concrete Elm values.
 
 ### State Combinators
 
-@docs withState, putState, modifyState, withLocation, withLine, withColumn, currentLocation, currentSourceLine, currentLine, currentColumn
+@docs withState, putState, modifyState, withLocation, withLine, withColumn, currentLocation, currentSourceLine, currentLine, currentColumn, modifyStream
 
 -}
 


### PR DESCRIPTION
Hi, it took a while, but I had added one function `modifyStream` that can be used to inject strings into the parse string. I use it to define statefull macros, that inject code at compile time into the code while parsing. See, https://liascript.github.io ... 

It would be great, if you could add this simple function, so that I could switch back to your repo in my project.

Regards

André